### PR TITLE
Added 'Ioc' type alias.

### DIFF
--- a/packages/flutter_ioc/CHANGELOG.md
+++ b/packages/flutter_ioc/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.0
+
+* Adds the `Ioc` alias to allow developers to access the `IocContainer` class in a shorter way.
+
 ## 2.0.0
 
 * **BREAKING CHANGE:** Removes the hard dependency on `get_it`, which means:

--- a/packages/flutter_ioc/lib/src/ioc_container.dart
+++ b/packages/flutter_ioc/lib/src/ioc_container.dart
@@ -10,6 +10,10 @@ enum ScopeChange {
   removed,
 }
 
+/// A shorter alias for the [IocContainer] type. This allows developers to
+/// use the shorter `Ioc.container` syntax instead of writing the full name.
+typedef Ioc = IocContainer;
+
 /// A standard interface providing inversion of control services to Dart or
 /// Flutter applications.
 abstract class IocContainer {

--- a/packages/flutter_ioc/pubspec.yaml
+++ b/packages/flutter_ioc/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_ioc
 description: A standard interface providing inversion of control services to Dart or Flutter applications.
-version: 2.0.0
+version: 2.1.0
 
 publish_to: none
 


### PR DESCRIPTION
Allows developers to access the `IocContainer` using a shorter syntax. Instead of using `IocContainer.container` developers can now use `Ioc.container`.