### PR TITLE
Trigger on correct tag

### DIFF
--- a/.github/workflows/flutter_ioc.yaml
+++ b/.github/workflows/flutter_ioc.yaml
@@ -9,7 +9,7 @@ on:
       - "packages/flutter_ioc/**"
       - ".github/workflows/flutter_ioc.yaml"
     tags:
-      - "v[0-9]+.[0-9]+.[0-9]+*"
+      - "^flutter_ioc_v[0-9]+.[0-9]+.[0-9]+*"
   pull_request:
     branches: [main]
     paths:


### PR DESCRIPTION
Release tags for Flutter packages should always start with the full packages name followed with the version number.

## Pre-launch Checklist

- [x] I made sure the project builds.
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I updated `pubspec.yaml` with an appropriate new version according to the [pub versioning philosophy], or this PR is does not need version changes.
- [x] I updated `CHANGELOG.md` to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I rebased onto `main`.
- [x] I added new tests to check the change I am making, or this PR does not need tests.
- [x] I made sure all existing and new tests are passing.
- [x] I ran `dart format .` and committed any changes.
- [x] I ran `flutter analyze` and fixed any errors.

<!-- References -->
[Contributor Guide]: https://github.com/Baseflow/screenrecorder/blob/main/CONTRIBUTING.md
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning